### PR TITLE
Fixed an OoB error while iterating over Main.tile

### DIFF
--- a/Sounds/SoundFilters/SoundFilterSystem.cs
+++ b/Sounds/SoundFilters/SoundFilterSystem.cs
@@ -539,7 +539,7 @@ public class SoundFilterSystem : ModSystem {
                 y0 += sy;
             }
 
-            Tile tile = Main.tile[x0, y0];
+            Tile tile = Framing.GetTileSafely(x0, y0);
 
             bool? cb = touchCallback?.Invoke(x0, y0, tile);
             if (cb == true) break;


### PR DESCRIPTION
This was brought to my attention when a boss was consistently despawning as a projectile death sound with no particular properties played when this mod was enabled and I traced the stack and was led to this, this should fix issues like that hopefully